### PR TITLE
Fix 7z check

### DIFF
--- a/Install Windows.bat
+++ b/Install Windows.bat
@@ -1,8 +1,8 @@
 <# : Installation.bat
 @echo off
+pushd %~dp0
 setlocal
 title Install Windows without USB
-cd %~dp0
 
 :: CHECK FOR ADMIN PRIVILEGES
 dism >nul 2>&1 || (echo This script must be Run as Administrator. && pause && exit /b 1)


### PR DESCRIPTION
Looks like I made a mistake.. When the script is run as admin it operates in C:\Windows\System32, and is checking for C:\Windows\System32\7z.exe, not under the script directory. This should fix that